### PR TITLE
Add classification pipeline for teeth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Worker RunPod pour analyse dentaire
 
-Ce projet fournit un worker compatible avec la plateforme RunPod. Il applique les modèles de détection `dents`, `bridges` et `implants` sur l'image reçue, attribue les numéros FDI puis retourne un résumé.
+Ce projet fournit un worker compatible avec la plateforme RunPod. Il applique les modèles de détection `dents`, `bridges` et `implants` sur l'image reçue, attribue les numéros FDI puis passe chaque dent à travers trois modèles de classification (`classes_dent`, `endo`, `restauration`). Les dents détectées sont recadrées en `224x224` avec des bandes noires pour conserver le ratio avant d'être classées. Le handler retourne ensuite un résumé complet.
 
 ## Utilisation locale
 


### PR DESCRIPTION
## Summary
- integrate tooth classification models
- crop detections to 224x224 before running classifiers
- save classification results alongside detection data
- document classification step in README

## Testing
- `python -m py_compile main_logic.py handler.py`
- `pip install -r requirements.txt` *(fails: environment lacks resources)*

------
https://chatgpt.com/codex/tasks/task_e_6848924bcda08330bba58569a4c7a5b5